### PR TITLE
Show all previous lookup parameters when erroring in get()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,14 +78,16 @@ exception::
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "tasklib/task.py", line 224, in get
-        'Lookup parameters were {0}'.format(kwargs))
-    tasklib.task.DoesNotExist: Task matching query does not exist. Lookup parameters were {'status': 'completed'}
+        clone.filter_obj.get_filter_params()
+    tasklib.task.DoesNotExist: Task matching query does not exist.
+    Lookup parameters were ['status:pending', 'tags.contain:work', 'status:completed']
     >>> tw.tasks.filter(status='pending', tags__contain='home').get()
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "tasklib/task.py", line 227, in get
-        'Lookup parameters were {1}'.format(num, kwargs))
-    ValueError: get() returned more than one Task -- it returned 2! Lookup parameters were {}
+        num, clone.filter_obj.get_filter_params()
+    ValueError: get() returned more than one Task -- it returned 2!
+    Lookup parameters were ['status:pending', 'tags.contain:home']
 
 Task Attributes
 ---------------

--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -265,11 +265,15 @@ class TaskQuerySet(object):
             return clone._result_cache[0]
         if not num:
             raise Task.DoesNotExist(
-                'Task matching query does not exist. '
-                'Lookup parameters were {0}'.format(kwargs))
+                'Task matching query does not exist.\n'
+                'Lookup parameters were {0}'.format(
+                    clone.filter_obj.get_filter_params()
+                ))
         raise ValueError(
-            'get() returned more than one Task -- it returned {0}! '
-            'Lookup parameters were {1}'.format(num, kwargs))
+            'get() returned more than one Task -- it returned {0}!\n'
+            'Lookup parameters were {1}'.format(
+                num, clone.filter_obj.get_filter_params()
+            ))
 
 
 class TaskWarrior(object):


### PR DESCRIPTION
If you got this error, with the filters specified in the order that they were added, it should be easier to work out, for instance, where one particular filter you didn't expect to be applied has come from. I'm not sure if this is the best way to do this, and I'm _super_ not sure if the formatting is sensible.
