### PR TITLE
travis: Use git repository for sources, expand task versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 env:
-  - TASK_VERSION=2.1.1
-  - TASK_VERSION=2.1.2
-  - TASK_VERSION=2.2.0
+  - TASK_VERSION=v2.1.1
+  - TASK_VERSION=v2.1.2
+  - TASK_VERSION=v2.2.0
+  - TASK_VERSION=v2.3.0
+  - TASK_VERSION=2.4.0.beta2
+  - TASK_VERSION=2.4.0
 python:
   - "2.6"
   - "2.7"
@@ -12,9 +15,10 @@ python:
 install:
   - pip install -e .
   - sudo apt-get install -qq build-essential cmake uuid-dev
-  - wget http://archive.ubuntu.com/ubuntu/pool/universe/t/task/task_$TASK_VERSION.orig.tar.gz
-  - tar -zxvf task_$TASK_VERSION.orig.tar.gz
-  - cd task-$TASK_VERSION
+  - git clone https://git.tasktools.org/scm/tm/task.git
+  - cd task
+  - git checkout $TASK_VERSION
+  - git clean -dfx
   - cmake .
   - make
   - sudo make install


### PR DESCRIPTION
The 2.4.0.beta2 branch is failing, though I have been unable to reproduce this manually.

Interestingly enough, the 2.4.0 branch works.
