### PR TITLE
Add workaround for TW-1452 bug

### DIFF
--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -163,7 +163,13 @@ class TaskFilter(object):
         # Replace the value with empty string, since that is the
         # convention in TW for empty values
         value = value if value is not None else ''
-        self.filter_params.append('{0}:{1}'.format(key, value))
+
+        # If we are filtering by uuid:, do not use uuid keyword
+        # due to TW-1452 bug
+        if key == 'uuid':
+            self.filter_params.insert(0, value)
+        else:
+            self.filter_params.append('{0}:{1}'.format(key, value))
 
     def get_filter_params(self):
         return [f for f in self.filter_params if f]


### PR DESCRIPTION
There is nasty bug in TW, which prevents you from filtering by UUID. It seems it won't be fixed soon, so we need a workaround in tasklib.

See: https://bug.tasktools.org/browse/TW-1452
