### PR TITLE
Task: Add 'completed' parameter to the Task object

### DIFF
--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -84,6 +84,14 @@ class Task(TaskResource):
     def __unicode__(self):
         return self['description']
 
+    @property
+    def completed(self):
+        """
+        Returns true if task has been completed, false otherwise.
+        """
+
+        return self['id'] == 0
+
     def serialize_due(self, date):
         return date.strftime(DATE_FORMAT)
 


### PR DESCRIPTION
I find property on the Task object itself more useful and concise than typing comparing task ID to 0 each time.
