### PR TITLE
Readme: Fix travis badge on the develop branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 tasklib
 =======
 
-.. image:: https://travis-ci.org/robgolding63/tasklib.png
+.. image:: https://travis-ci.org/robgolding63/tasklib.png?branch=develop
     :target: http://travis-ci.org/robgolding63/tasklib
 
 .. image:: https://coveralls.io/repos/robgolding63/tasklib/badge.png?branch=develop


### PR DESCRIPTION
The badge should not show fails when arbitrary pull request fails (which is the behaviour now).