### PR TITLE
Make sure modified fields were actually modified

### DIFF
--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -245,7 +245,15 @@ class Task(TaskResource):
     def _modified_fields(self):
         writable_fields = set(self._data.keys()) - set(self.read_only_fields)
         for key in writable_fields:
-            if self._data.get(key) != self._original_data.get(key):
+            new_value = self._data.get(key)
+            old_value = self._original_data.get(key)
+
+            # Make sure not to mark data removal as modified field if the
+            # field originally had some empty value
+            if key in self._data and not new_value and not old_value:
+                continue
+
+            if new_value != old_value:
                 yield key
 
     @property

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -7,6 +7,29 @@ import unittest
 
 from .task import TaskWarrior, Task
 
+# http://taskwarrior.org/docs/design/task.html , Section: The Attributes
+TASK_STANDARD_ATTRS = (
+    'status',
+    'uuid',
+    'entry',
+    'description',
+    'start',
+    'end',
+    'due',
+    'until',
+    'wait',
+    'modified',
+    'scheduled',
+    'recur',
+    'mask',
+    'imask',
+    'parent',
+    'project',
+    'priority',
+    'depends',
+    'tags',
+    'annotation',
+)
 
 class TasklibTest(unittest.TestCase):
 
@@ -409,6 +432,14 @@ class TaskTest(TasklibTest):
         t['due'] = datetime.datetime(2014, 2, 14, 14, 14, 14)  # <3
         t['project'] = "test project"
         t['depends'] = set([dependency])
+        self.assertEqual(set(t._modified_fields), set())
+
+    def test_modified_fields_not_affected_by_reading(self):
+        t = Task(self.tw)
+
+        for field in TASK_STANDARD_ATTRS:
+            value = t[field]
+
         self.assertEqual(set(t._modified_fields), set())
 
     def test_setting_read_only_attrs_through_init(self):


### PR DESCRIPTION
Fixes a nitpick bug in #19 , and adds a test for it.