### PR TITLE
Be robust to invalid utf-8 characters in task db

### DIFF
--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -149,7 +149,7 @@ class TaskWarrior(Backend):
             self._get_task_command() + ['--version'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
-        stdout, stderr = [x.decode('utf-8') for x in p.communicate()]
+        stdout, stderr = [x.decode('utf-8', errors='ignore') for x in p.communicate()]
         return stdout.strip('\n')
 
     def _get_modified_task_fields_as_args(self, task):


### PR DESCRIPTION
Sometimes, there may exist non-printable characters in the taskwarrior `pending.data` file, for example due to an emoji added to the task description but is not yet properly parsed by python. In these cases, we'd want `tasklib` not to crash but rather ignore it and keep parsing the results of the command.