### PR TITLE
Make filter method take a string, eg for use with `tags.contains:foo`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ tasklib has a similar API to that of Django's ORM::
     >>> tasks = tw.tasks.pending()
     >>> tasks
     ['Tidy the house', 'Learn German']
-    >>> tasks.filter(tags__contain='chores')
+    >>> tasks.filter(tags__contains='chores')
     ['Tidy the house']
     >>> type(tasks[0])
     <class 'tasklib.task.Task'>

--- a/tasklib/serializing.py
+++ b/tasklib/serializing.py
@@ -174,7 +174,13 @@ class SerializingObject(object):
         return [TaskAnnotation(self, d) for d in data] if data else []
 
     def serialize_tags(self, tags):
-        return ','.join(tags) if tags else ''
+        if isinstance(tags, list):
+            tags = set(tags)
+        if isinstance(tags, set):
+            return ','.join(tags) if tags else ''
+        if isinstance(tags, str):
+            return tags
+        raise ValueError("serialize_tags only supports list, set or string")
 
     def deserialize_tags(self, tags):
         if isinstance(tags, str):


### PR DESCRIPTION
The example in README says this works:
```
tw.tasks.pending().filter(tags__contains='testing')
```
but actually in `deserialize_tags()`, which ends up getting this, there is expectation for a list parameter, so not sure how the example from README ever worked (!)

This patch changes `.filter()` method to support a string argument also, which in that case is passed through unchanged.  This makes the README example work again.

Fixes #116