### PR TITLE
allow an empty string as the value for "wait"-like expressions

### DIFF
--- a/tasklib/serializing.py
+++ b/tasklib/serializing.py
@@ -237,7 +237,10 @@ class SerializingObject(object):
                 # time zone at this point. Also None is a valid value too.
                 localized = value
         elif isinstance(value, str):
-            localized = self.backend.convert_datetime_string(value)
+            if value == '':
+                localized = value
+            else:
+                localized = self.backend.convert_datetime_string(value)
         else:
             raise ValueError("Provided value could not be converted to "
                              "datetime, its type is not supported: {}"


### PR DESCRIPTION
so we can pass empty value expressions to `.filter()` like to get effect of giving a `-WAITING` filter to TaskWarrior, eg with `.filter(wait__none='')`

Fixes #118