### PR TITLE
fix(backend): expand vars for rc and data location

### DIFF
--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -95,7 +95,8 @@ class TaskWarrior(Backend):
                  version_override=None):
         self.taskrc_location = None
         if taskrc_location:
-            self.taskrc_location = os.path.expanduser(taskrc_location)
+            self.taskrc_location = os.path.expandvars(taskrc_location)
+            self.taskrc_location = os.path.expanduser(self.taskrc_location)
 
             # If taskrc does not exist, pass / to use defaults and avoid creating
             # dummy .taskrc file by TaskWarrior
@@ -121,6 +122,7 @@ class TaskWarrior(Backend):
 
         # Set data.location override if passed via kwarg
         if data_location is not None:
+            data_location = os.path.expandvars(data_location)
             data_location = os.path.expanduser(data_location)
             if create and not os.path.exists(data_location):
                 os.makedirs(data_location)


### PR DESCRIPTION
When passing an environment variable such as $XDG_CONFIG_HOME or
$XDG_DATA_HOME to a TaskWarrior instance of the library, the variables
are not expanded leading to ignoring rc_location or creating a path like
'~/$XDG_DATA_HOME'.

Encountered this behavior using taskwiki vim plugin which does not expand
any variables either.