### PR TITLE
Add TaskWarrior().purge_task() - Permanently remove Task instances

### DIFF
--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -362,6 +362,12 @@ class TaskWarrior(Backend):
     def delete_task(self, task):
         self.execute_command([task['uuid'], 'delete'])
 
+    def purge_task(self, task):
+        """
+        Permanently remove the task.  This causes data loss.
+        """
+        self.execute_command([task['uuid'], 'purge'])
+
     def start_task(self, task):
         self.execute_command([task['uuid'], 'start'])
 

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -366,6 +366,7 @@ class TaskWarrior(Backend):
         """
         Permanently remove the task.  This causes data loss.
         """
+        self.execute_command([task['uuid'], 'delete'])
         self.execute_command([task['uuid'], 'purge'])
 
     def start_task(self, task):


### PR DESCRIPTION
This PR adds `purge_task()` which is a missing part of the official TaskWarrior API.

I templated this off the `delete_task()` method and added a force purge before delete in case the user forgets.